### PR TITLE
Add getUsage method to display the usage string for a command

### DIFF
--- a/lib/command-line-commands.js
+++ b/lib/command-line-commands.js
@@ -79,6 +79,24 @@ class CommandLineCommands {
     }
     return output
   }
+
+  /**
+   * Generates a usage guide for the specified command. Please see [command-line-usage](https://github.com/75lb/command-line-usage) for full instructions of how to use.
+   *
+   * @param [commandName] {string} - the command to load the command line option definitions from
+   * @param [options] {object} - the options to pass to [command-line-usage](https://github.com/75lb/command-line-usage)
+   * @returns {string}
+   */
+  getUsage (commandName, options) {
+    var output = '';
+    const commandDefinition = this.commands.find(c => c.name === commandName)
+    if (commandDefinition) {
+      const cli = commandLineArgs(commandDefinition.definitions)
+      output = cli.getUsage(options);
+    }
+
+    return output;
+  }
 }
 
 function factory (commands) {

--- a/test/test.js
+++ b/test/test.js
@@ -46,3 +46,17 @@ test('parse: no definitions, but options passed', function (t) {
   })
   t.end()
 })
+
+test('usage: simple', function (t) {
+  var commands = [
+    {
+      name: 'eat',
+      definitions: [ { name: 'food', description: 'food option' } ]
+    }
+  ];
+  var cli = commandLineCommands(commands);
+  var usage = cli.getUsage('eat', { title: 'test' });
+  t.ok(/test/.test(usage), 'title present');
+  t.ok(/food option/.test(usage), 'description present');
+  t.end()
+})


### PR DESCRIPTION
Just a wrapper to call the `getUsage` for each of the commands so the output can be displayed
