### PR TITLE
Feature: handle unknown command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ switch (command.name) {
     console.log(`${command.options.why}: this is not a good reason.`)
     break
   default:
-    console.log('Unknown command.')
+    console.log(command.error + ':' + command.command);
+
 }
 ```
 
@@ -45,7 +46,7 @@ $ example run --why terror
 terror: this is not a good reason.
 
 $ example hide
-Unknown command.
+Unknown command: hide
 ```
 
 * [command-line-commands](#module_command-line-commands)

--- a/es5/command-line-commands.js
+++ b/es5/command-line-commands.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -9,7 +9,7 @@ var arrayify = require('array-back');
 
 module.exports = factory;
 
-var CommandLineCommands = (function () {
+var CommandLineCommands = function () {
   function CommandLineCommands(commands) {
     _classCallCheck(this, CommandLineCommands);
 
@@ -35,13 +35,16 @@ var CommandLineCommands = (function () {
         var cli = commandLineArgs(commandDefinition.definitions);
         output.name = commandName;
         output.options = cli.parse(argv);
+      } else {
+        output.error = 'Unknown command';
+        output.command = commandName;
       }
       return output;
     }
   }]);
 
   return CommandLineCommands;
-})();
+}();
 
 function factory(commands) {
   return new CommandLineCommands(commands);

--- a/lib/command-line-commands.js
+++ b/lib/command-line-commands.js
@@ -28,7 +28,8 @@ const arrayify = require('array-back')
  *     console.log(`${command.options.why}: this is not a good reason.`)
  *     break
  *   default:
- *     console.log('Unknown command.')
+ *     console.log(command.error + ':' + command.command);
+ *
  * }
  * ```
  *
@@ -41,7 +42,7 @@ const arrayify = require('array-back')
  * terror: this is not a good reason.
  *
  * $ example hide
- * Unknown command.
+ * Unknown command: hide
  * ```
  */
 module.exports = factory
@@ -76,6 +77,9 @@ class CommandLineCommands {
       const cli = commandLineArgs(commandDefinition.definitions)
       output.name = commandName
       output.options = cli.parse(argv)
+    } else {
+      output.error = 'Unknown command';
+      output.command = commandName;
     }
     return output
   }

--- a/test/test.js
+++ b/test/test.js
@@ -46,3 +46,14 @@ test('parse: no definitions, but options passed', function (t) {
   })
   t.end()
 })
+
+test('parse: unknown command', function (t) {
+  var commands = [ { name: 'eat' } ];
+  var cli = commandLineCommands(commands)
+  var command = cli.parse([ 'sleep' ])
+  t.deepEqual(command, {
+    error: 'Unknown command',
+    command: 'sleep'
+  })
+  t.end()
+})


### PR DESCRIPTION
Having command-line-commands return the command it doesn't understand makes it cleaner for to show what went wrong.
