### PR TITLE
update commandLineArgs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ if (command === null) {
   ]
 
   // pass in the `argv` returned by `commandLineCommands()`
-  const options = commandLineArgs(optionDefinitions, argv)
+  const options = commandLineArgs(optionDefinitions, { argv: argv })
 
   if (options.version) {
     console.log('version 1.0.1')


### PR DESCRIPTION
commandLineArgs used to take an optional argv array as its second parameter.
Now it takes an optional options object with an optional argv property instead.
This change updates the usage example to reflect that change.