### PR TITLE
Point package's main path to the actual entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Add a git-like command interface to your app.",
   "repository": "https://github.com/75lb/command-line-commands.git",
   "license": "MIT",
-  "main": "lib/command-line-commands.js",
+  "main": "index.js",
   "files": [
     "index.js",
     "option.js"


### PR DESCRIPTION
Hi :wave:,

I'm currently trying to use this module (or rather a module that uses this module) in deno by importing it via [jspm.dev](https://jspm.dev/npm:command-line-commands).
I was running into issues there and realized that the `package.json` in this module has the `main` entry `lib/command-line-commands.js`, which does not seem to make any sense - whether pre- or post-build.

I assume this might be a problem with other bundling strategies as well and to be honest I'm surprised it doesn't cause problems in node.js.

Is changing the `main` field to `index.js` alright with you?

Kind regards,
yeldiR